### PR TITLE
Fix message table order

### DIFF
--- a/src/app/api/texts-bc/route.ts
+++ b/src/app/api/texts-bc/route.ts
@@ -98,7 +98,7 @@ export async function GET(request: NextRequest) {
         conflict_detected
       FROM "texts-bc" 
       ${whereClause}
-      ORDER BY date_time DESC 
+      ORDER BY date_time ASC
       LIMIT ? OFFSET ?
     `;
 

--- a/src/page.tsx
+++ b/src/page.tsx
@@ -39,14 +39,14 @@ export default function Page() {
   const [textsLoading, setTextsLoading] = useState(true);
   const [textsPagination, setTextsPagination] = useState({
     page: 1,
-    limit: 50,
+    limit: 100,
     total: 0,
     totalPages: 0
   });
   const [selectedMonthMessages, setSelectedMonthMessages] = useState<TextMessage[]>([]);
   const [selectedMonthLoading, setSelectedMonthLoading] = useState(false);
 
-  const fetchTextsData = async (page: number = 1, limit: number = 50) => {
+  const fetchTextsData = async (page: number = 1, limit: number = 100) => {
     setTextsLoading(true);
     try {
       const response = await fetch(`/api/texts-bc?page=${page}&limit=${limit}`);
@@ -83,7 +83,7 @@ export default function Page() {
       const endDate = new Date(year, month + 1, 0, 23, 59, 59); // Last day of month
       
       // Fetch messages for this date range
-      const response = await fetch(`/api/texts-bc?start_date=${startDate.toISOString()}&end_date=${endDate.toISOString()}&limit=100`);
+      const response = await fetch(`/api/texts-bc?start_date=${startDate.toISOString()}&end_date=${endDate.toISOString()}&limit=1000`);
       const result: TextsApiResponse = await response.json();
       
       if (result.success && result.data) {


### PR DESCRIPTION
### **User description**
## Summary
- show oldest messages first in the texts API
- increase default row limit on homepage
- fetch up to 1000 messages when drilling into a month

## Testing
- `npm run check`
- `npm run test` *(fails: Timed out waiting 60000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_b_6884f64fd8b0832bbb6a77d80f816a6e


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix message ordering to show oldest first

- Increase homepage row limit from 50 to 100

- Expand monthly drill-down limit to 1000 messages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["API Route"] --> B["Change ORDER BY DESC to ASC"]
  C["Homepage"] --> D["Increase default limit 50→100"]
  C --> E["Increase monthly limit 100→1000"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Fix message ordering to chronological</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/texts-bc/route.ts

- Changed ORDER BY clause from DESC to ASC for chronological ordering


</details>


  </td>
  <td><a href="https://github.com/MeganHarrison/next-starter-template/pull/3/files#diff-195ede1a34780afe15e3d364f4fb1d285f305d0fcb4893c295d891f26333dee7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Increase pagination limits for better visibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/page.tsx

<ul><li>Increased default pagination limit from 50 to 100 rows<br> <li> Updated fetchTextsData function default parameter<br> <li> Increased monthly drill-down limit from 100 to 1000 messages</ul>


</details>


  </td>
  <td><a href="https://github.com/MeganHarrison/next-starter-template/pull/3/files#diff-514d17c76993538e38a20f09464104a88f27e54b4626ed9baaef917aade74110">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

